### PR TITLE
Add collection of Galera metrics to the config template

### DIFF
--- a/config/plugin.template.json
+++ b/config/plugin.template.json
@@ -3,7 +3,7 @@
     {
       "name"    : "Localhost",
       "host"    : "localhost",
-      "metrics" : "status,newrelic",
+      "metrics" : "status,newrelic,galera",
       "user"    : "USER_NAME_HERE",
       "passwd"  : "USER_PASSWD_HERE"
     }


### PR DESCRIPTION
After installation the tab holding Galera metrics is empty and I've lost quite a bit of time to figure out why is that.

I needed just to enable collection of galera metrics in JSON config.
Unless there are common use cases where it should be disabled I think it is a good idea to have that enabled by default.
